### PR TITLE
fix(FEC-10799): poster has no width and height

### DIFF
--- a/components/poster.brs
+++ b/components/poster.brs
@@ -34,8 +34,12 @@ function _selectPosterByPlayerDimensions(posters as object, playerWidth as integ
     min = 9999999999
     url = ""
     For each poster in posters
-        picWidth = poster.width
-        picHeight = poster.height
+        picHeight = 0
+        picWidth = 0
+        posterWidth = Val(StringUtil().toString(poster.width))
+        posterHeight = Val(StringUtil().toString(poster.width))
+        if poster.width <> invalid and posterWidth > 0 then picWidth = posterWidth
+        if poster.height <> invalid and posterHeight > 0 then picHeight = posterHeight
         widthDelta = Abs(picWidth - playerWidth)
         heightDelta = Abs(picHeight - playerHeight)
         delta = widthDelta + heightDelta


### PR DESCRIPTION
### Description of the Changes

Issue: Abs doesn't know to use invalid as 0, need to set it explicitly.
Solution: set explicit 0 and check for valid value(number).

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
